### PR TITLE
Update AzureOpenAIConfig validation to cater for reverse proxy endpoi…

### DIFF
--- a/extensions/AzureOpenAI/AzureOpenAI/AzureOpenAIConfig.cs
+++ b/extensions/AzureOpenAI/AzureOpenAI/AzureOpenAIConfig.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
 using System;
+using System.Collections.Generic;
 using Azure.Core;
 
 #pragma warning disable IDE0130 // reduce number of "using" statements
@@ -82,6 +83,12 @@ public class AzureOpenAIConfig
     /// How many times to retry in case of throttling.
     /// </summary>
     public int MaxRetries { get; set; } = 10;
+
+    /// <summary>
+    /// Thumbprints of certificates that should be trusted for HTTPS requests when SSL policy errors are detected.
+    /// This should only be used for local development when using a proxy to call the OpenAI endpoints.
+    /// </summary>
+    public HashSet<string> TrustedCertificateThumbprints { get; set; } = [];
 
     /// <summary>
     /// Set credentials manually from code

--- a/service/Service/appsettings.json
+++ b/service/Service/appsettings.json
@@ -339,7 +339,10 @@
         // See https://learn.microsoft.com/azure/ai-services/openai/reference#embeddings
         "MaxEmbeddingBatchSize": 1,
         // How many times to retry in case of throttling.
-        "MaxRetries": 10
+        "MaxRetries": 10,
+        // Thumbprints of certificates that should be trusted for HTTPS requests when SSL policy errors are detected.
+        // This should only be used for local development when using a proxy to call the OpenAI endpoints.
+        "TrustedCertificateThumbprints": []
       },
       "AzureOpenAIText": {
         // "ApiKey" or "AzureIdentity"
@@ -355,7 +358,10 @@
         // "ChatCompletion" or "TextCompletion"
         "APIType": "ChatCompletion",
         // How many times to retry in case of throttling.
-        "MaxRetries": 10
+        "MaxRetries": 10,
+        // Thumbprints of certificates that should be trusted for HTTPS requests when SSL policy errors are detected.
+        // This should only be used for local development when using a proxy to call the OpenAI endpoints.
+        "TrustedCertificateThumbprints": []
       },
       "AzureQueues": {
         // "ConnectionString" or "AzureIdentity". For other options see <AzureQueueConfig>.


### PR DESCRIPTION
…nt (#875)

## Motivation and Context (Why the change? What's the scenario?)

The intent of the change in this PR is to allow Azure OpenAI requests to be made over HTTP to a reverse proxy that is running within the same Docker Compose orchestration for local development.

We have reverse proxy in place for Azure OpenAI that routes requests to different service instances based on available quota. When deployed to Azure all services can use HTTPS and Kernel Memory can use the reverse proxy for Azure OpenAI requests.

Visual Studio with Docker Compose orchestration is used for local development. The reverse proxy project is started and exposes both HTTP and HTTPS ports. A local dev certificate is used automatically by the tooling and the reverse proxy can be called over HTTPS from the host machine using `localhost`.

## High level description (Approach, Design)

Update the validation in the `AzureOpenAIConfig` class:

- Allow to define a custom list of SSL cert thumbprints to be trusted

---------

<!-- Thank you for your contribution! Please provide the following information -->
## Motivation and Context (Why the change? What's the scenario?)


## High level description (Approach, Design)

